### PR TITLE
Ensuring that children are sorted

### DIFF
--- a/lib/locabulary.rb
+++ b/lib/locabulary.rb
@@ -54,7 +54,7 @@ module Locabulary
   def associate_parents_and_childrens_for(hierarchy_graph_keys, items, predicate_name)
     items.each do |item|
       begin
-        hierarchy_graph_keys.fetch(item.parent_term_label).children << item unless item.parent_slugs.empty?
+        hierarchy_graph_keys.fetch(item.parent_term_label).add_child(item) unless item.parent_slugs.empty?
       rescue KeyError => error
         raise Exceptions::MissingHierarchicalParentError.new(predicate_name, error)
       end

--- a/lib/locabulary/items/administrative_unit.rb
+++ b/lib/locabulary/items/administrative_unit.rb
@@ -32,7 +32,13 @@ module Locabulary
         @children = []
       end
 
-      attr_reader :children
+      def children
+        @children.sort
+      end
+
+      def add_child(*input)
+        @children += input
+      end
 
       HIERARCHY_SEPARATOR = '::'.freeze
       def slugs

--- a/spec/lib/locabulary/items/administrative_unit_spec.rb
+++ b/spec/lib/locabulary/items/administrative_unit_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe Locabulary::Items::AdministrativeUnit do
     end
   end
 
+  context '#add_child' do
+    it 'updates the children' do
+      expect { subject.add_child('tuna', 'sandwich') }.to change { subject.children.count }.by(2)
+    end
+  end
+
   context '#selectable_label' do
     it 'excludes the root' do
       expect(subject.selectable_label).to eq('Galaxy::Planet')

--- a/spec/lib/locabulary_spec.rb
+++ b/spec/lib/locabulary_spec.rb
@@ -44,10 +44,10 @@ RSpec.describe Locabulary do
 
       expect(root.term_label).to(eq(item3.fetch(:term_label)), "with only one item at root level")
       expect(root.children.size).to eq(2)
-      expect(root.children.map(&:term_label)).to eq([item1.fetch(:term_label), item4.fetch(:term_label)])
+      expect(root.children.map(&:term_label)).to eq([item4.fetch(:term_label), item1.fetch(:term_label)])
       expect(
         root.children.find { |node| node.term_label == 'Universe::Galaxy' }.children.map(&:term_label)
-      ).to eq([item2.fetch(:term_label), item5.fetch(:term_label)])
+      ).to eq([item5.fetch(:term_label), item2.fetch(:term_label)])
       expect(root.children.find { |node| node.term_label == 'Universe::Non-Galactic' }.children.map(&:term_label)).to eq([])
     end
     it 'fails if we have more than one root node' do


### PR DESCRIPTION
Prior to this commit, the sort order of children was based on input
order. By moving towards the #add_child method I can always sort the
children when they are accessed.