### PR TITLE
Handling non-department selectable_label

### DIFF
--- a/lib/locabulary/items/administrative_unit.rb
+++ b/lib/locabulary/items/administrative_unit.rb
@@ -61,8 +61,13 @@ module Locabulary
         children.count == 0
       end
 
+      NON_DEPARTMENTAL_SLUG = "Non-Departmental".freeze
       def selectable_label
-        slugs[1..-1].join(HIERARCHY_SEPARATOR)
+        if slugs[-1] == NON_DEPARTMENTAL_SLUG
+          slugs[-2..-1].join(HIERARCHY_SEPARATOR)
+        else
+          slugs[-1]
+        end
       end
 
       alias selectable_id id

--- a/lib/locabulary/items/administrative_unit.rb
+++ b/lib/locabulary/items/administrative_unit.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'locabulary/exceptions'
 require 'locabulary/items/base'
 
@@ -62,9 +63,11 @@ module Locabulary
       end
 
       NON_DEPARTMENTAL_SLUG = "Non-Departmental".freeze
+      # NOTE: The whitespace characters are "thin spaces", U+200A
+      HUMAN_FRIENDLY_HIERARCHY_SEPARATOR = ' — '.freeze
       def selectable_label
         if slugs[-1] == NON_DEPARTMENTAL_SLUG
-          slugs[-2..-1].join(HIERARCHY_SEPARATOR)
+          slugs[-2..-1].join(HUMAN_FRIENDLY_HIERARCHY_SEPARATOR)
         else
           slugs[-1]
         end

--- a/spec/lib/locabulary/items/administrative_unit_spec.rb
+++ b/spec/lib/locabulary/items/administrative_unit_spec.rb
@@ -39,7 +39,9 @@ RSpec.describe Locabulary::Items::AdministrativeUnit do
     end
     it 'is the second to last and last slug if we have a Non-Departmental last slug' do
       subject = Locabulary::Items::AdministrativeUnit.new(term_label: "Universe::Galaxy::#{described_class::NON_DEPARTMENTAL_SLUG}")
-      expect(subject.selectable_label).to eq("Galaxy::#{described_class::NON_DEPARTMENTAL_SLUG}")
+      expect(subject.selectable_label).to eq(
+        "Galaxy#{described_class::HUMAN_FRIENDLY_HIERARCHY_SEPARATOR}#{described_class::NON_DEPARTMENTAL_SLUG}"
+      )
     end
   end
 

--- a/spec/lib/locabulary/items/administrative_unit_spec.rb
+++ b/spec/lib/locabulary/items/administrative_unit_spec.rb
@@ -34,8 +34,12 @@ RSpec.describe Locabulary::Items::AdministrativeUnit do
   end
 
   context '#selectable_label' do
-    it 'excludes the root' do
-      expect(subject.selectable_label).to eq('Galaxy::Planet')
+    it 'is the last slug' do
+      expect(subject.selectable_label).to eq('Planet')
+    end
+    it 'is the second to last and last slug if we have a Non-Departmental last slug' do
+      subject = Locabulary::Items::AdministrativeUnit.new(term_label: "Universe::Galaxy::#{described_class::NON_DEPARTMENTAL_SLUG}")
+      expect(subject.selectable_label).to eq("Galaxy::#{described_class::NON_DEPARTMENTAL_SLUG}")
     end
   end
 


### PR DESCRIPTION
> The values in the select controls include “::” delimited values. Alex
> expressed concern about exposing machine-friendly data to our
> patrons. The solution that was originally arrived upon was to use the
> smallest unit of organization available execpt in the case of “Non
> departmental”. Alternatively, we could use more “human-friendly”
> punctuation/display.

Related to ndlib/curate_nd#347