### PR TITLE
Updating dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in vocabulary.gemspec
 gemspec
-
-gem 'dry-validation', github: 'dry-rb/dry-validation'
-gem 'dry-types', github: 'dry-rb/dry-types'

--- a/lib/locabulary/items.rb
+++ b/lib/locabulary/items.rb
@@ -1,5 +1,5 @@
 require 'locabulary/items/base'
-require 'hanami/utils/string'
+require 'active_support/core_ext/string/inflections'
 module Locabulary
   # A container for the various types of Locabulary Items
   module Items
@@ -19,7 +19,7 @@ module Locabulary
     # @option predicate_name [String] Used for lookup of the correct Locabulary::Item type
     def builder_for(options = {})
       predicate_name = options.fetch(:predicate_name)
-      possible_class_name_for_predicate_name = Hanami::Utils::String.new(predicate_name).singularize.classify
+      possible_class_name_for_predicate_name = predicate_name.singularize.classify
       klass = begin
         Items.const_get(possible_class_name_for_predicate_name)
       rescue NameError

--- a/lib/locabulary/items/administrative_unit.rb
+++ b/lib/locabulary/items/administrative_unit.rb
@@ -59,7 +59,7 @@ module Locabulary
       end
 
       def selectable?
-        children.count == 0
+        children.count.zero?
       end
 
       NON_DEPARTMENTAL_SLUG = "Non-Departmental".freeze

--- a/lib/locabulary/items/base.rb
+++ b/lib/locabulary/items/base.rb
@@ -89,9 +89,9 @@ module Locabulary
 
       def <=>(other)
         predicate_name_sort = predicate_name <=> other.predicate_name
-        return predicate_name_sort unless predicate_name_sort == 0
+        return predicate_name_sort unless predicate_name_sort.zero?
         presentation_sequence_sort = presentation_sequence <=> other.presentation_sequence
-        return presentation_sequence_sort unless presentation_sequence_sort == 0
+        return presentation_sequence_sort unless presentation_sequence_sort.zero?
         term_label <=> other.term_label
       end
 

--- a/lib/locabulary/json_creator.rb
+++ b/lib/locabulary/json_creator.rb
@@ -1,4 +1,3 @@
-require "google/api_client"
 require "google_drive"
 require 'highline/import'
 require 'locabulary'

--- a/lib/locabulary/schema.rb
+++ b/lib/locabulary/schema.rb
@@ -4,14 +4,14 @@ require 'dry/validation/schema'
 module Locabulary
   # Responsible for providing a defined and clear schema for each of the locabulary items.
   Schema = Dry::Validation.Schema do
-    key(:predicate_name).required(format?: /\A[a-z_]+\Z/)
-    key(:values).each do
-      key(:term_label).required(:str?)
+    required(:predicate_name).filled(format?: /\A[a-z_]+\Z/)
+    required(:values).each do
+      required(:term_label).filled(:str?)
       optional(:description).maybe(:str?)
       optional(:grouping).maybe(:str?)
       optional(:affiliation).maybe(:str?)
       optional(:default_presentation_sequence).maybe(:int?)
-      key(:activated_on).required(format?: /\A\d{4}-\d{2}-\d{2}\Z/)
+      required(:activated_on).filled(format?: /\A\d{4}-\d{2}-\d{2}\Z/)
       optional(:deactivated_on).maybe(format?: /\A\d{4}-\d{2}-\d{2}\Z/)
     end
   end

--- a/locabulary.gemspec
+++ b/locabulary.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "json", "~> 1.8"
   spec.add_dependency "dry-configurable"
-  spec.add_dependency "hanami-utils"
+  spec.add_dependency "activesupport", '~>4.0'
 
   spec.add_development_dependency "dry-validation"
   spec.add_development_dependency "bundler"
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency 'google_drive'
   spec.add_development_dependency 'highline'
-  spec.add_development_dependency "activesupport", "~>4.0"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "codeclimate-test-reporter"


### PR DESCRIPTION
## Removing Gemfile based dependencies

@dd22e4f30439b5b1a2cf9eaa44acfb681548c35a

The upstream changes are now part of released Rubygems. As such, we
don't need to leverage the Gemfile's feature of github references.

## Updating Dry::Validation::Schema usage

@e58c5ca16dcd7294944f10aa1b9bf5669159322b

There were a few deprecation warnings that have been removed as part
of these changes.

## Appeasing a change to Rubocop

@887d9f52dc7eee458b2d627786213a0538b35267

It now prefers `object.count.zero?` instead of `object.count == 0`

## Removing explicit require for google/api_client

@3a72ba193ba1d81d07142c252023e7140c69b250

The underlying library underwent a substantive change and the required
file no longer exists.

## Prefer ActiveSupport to Hanami

@ac4a6ca8765551f21ff09e90a8643224b2857590

As much as I would like to use Hanami as it is less invasive, it now
requires Ruby 2.2.0. This does not work for us at the moment so we
proceed with ActiveSupport.
