### PR TITLE
Updated to match affiliation change in curate_nd

### DIFF
--- a/data/affiliation.json
+++ b/data/affiliation.json
@@ -7,9 +7,13 @@
     "term_label": "Staff research and publications",
     "activated_on": "2015-01-01"
   },{
+    "term_label": "Postdoctoral research and publications",
+    "activated_on": "2016-09-15"
+  },{
     "term_label": "Graduate research and publications",
     "activated_on": "2015-01-01"
-  },{
+  }
+  ,{
     "term_label": "Undergraduate research and publications",
     "activated_on": "2015-01-01"
   },{


### PR DESCRIPTION
Put it in the same spot as in curate_nd.