### PR TITLE
Allow testing of multiple versions of active support

### DIFF
--- a/.fasterer.yml
+++ b/.fasterer.yml
@@ -2,3 +2,4 @@ speedups:
   each_with_index_vs_while: false
 exclude_paths:
   - 'vendor/**/*.rb'
+  - 'gemfiles/**/*.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ AllCops:
   Include:
     - Rakefile
   Exclude:
+    - 'gemfiles/**/*'
     - 'vendor/**/*'
     - 'tmp/**/*'
     - 'bin/**/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,22 @@
 language: ruby
 rvm:
-  - 2.2.2
-  - 2.0.0
+  - "2.0.0"
+  - "2.1.10"
+  - "2.2.8"
+  - "2.3.5"
+  - "2.4.2"
 cache: bundler
 sudo: false
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+
+matrix:
+  exclude:
+  - rvm: 2.0.0
+    gemfile: gemfiles/activesupport5.gemfile
+  - rvm: 2.1.10
+    gemfile: gemfiles/activesupport5.gemfile
+gemfile:
+  - gemfiles/activesupport5.gemfile
+  - gemfiles/activesupport4.gemfile

--- a/Rakefile
+++ b/Rakefile
@@ -13,9 +13,7 @@ unless Rake::Task.task_defined?('spec')
 end
 
 require 'rubocop/rake_task'
-RuboCop::RakeTask.new do |task|
-  task.options << "--config=.hound.yml"
-end
+RuboCop::RakeTask.new
 
 namespace :commitment do
   task :configure_test_for_code_coverage do

--- a/gemfiles/activesupport4.gemfile
+++ b/gemfiles/activesupport4.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in vocabulary.gemspec
+gemspec path: '../'
+gem 'activesupport', '~> 4.0'

--- a/gemfiles/activesupport5.gemfile
+++ b/gemfiles/activesupport5.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in vocabulary.gemspec
+gemspec path: '../'
+gem 'activesupport', '~> 5.0'

--- a/locabulary.gemspec
+++ b/locabulary.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "json", "~> 1.8"
   spec.add_dependency "dry-configurable", "~> 0.1.7"
-  spec.add_dependency "activesupport", '~>4.0'
+  spec.add_dependency "activesupport", '>= 4.0', "< 6.0"
 
   spec.add_development_dependency "dry-validation", "~> 0.9.5"
   spec.add_development_dependency "dry-logic", "~> 0.3.0"


### PR DESCRIPTION
## Allow testing of multiple versions of active support

4bd0f59380a3cbb684095ca10f9feee1e87a8457

Using the following documentation:
* [Travis for multiple versions of dependency][travis_multiple_versions_doc]
* [Travis for custom build matrix][travis_build_matrix]
* [Bundler][bundler_doc]

Travis for mutliple versions:

> To test against multiple versions of dependencies:
>
> 1. Create a directory in your project’s repository root where you will
>    keep gemfiles, such as ./gemfiles.
> 2. Add one or more gemfiles to it.
> 3. Set the the gemfile key in your .travis.yml.
>
> Thoughtbot’s Paperclip is tested against multiple ActiveRecord versions:
>
> ```yml
> gemfile:
>   - gemfiles/rails2.gemfile
>   - gemfiles/rails3.gemfile
>   - gemfiles/rails3_1.gemfile
> ```

Travis for custom build matrix:

> You can also define exclusions to the build matrix:
>
> ```yml
> matrix:
>   exclude:
>   - rvm: 1.9.3
>     gemfile: gemfiles/Gemfile.rails-2.3.x
>     env: ISOLATED=true
>   - rvm: jruby
>     gemfile: gemfiles/Gemfile.rails-2.3.x
>     env: ISOLATED=true
> ```

Bundler:

> As well, you can point to a specific gemspec using :path. If your
> gemspec is in /gemspec/path, use
> `gemspec :path => '/gemspec/path'`

[travis_multiple_versions_doc]:https://docs.travis-ci.com/user/languages/ruby/#Testing-against-multiple-versions-of-dependencies
[travis_build_matrix]:https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix
[bundler_doc]:http://bundler.io/rubygems.html

## Leveraging .rubocop.yml instead of .hound.yml

8b59c6f58fb3896ffba9835969139b23a410f106

.hound.yml is a carry over from HoundCI usage. We instead include
Rubocop as part of the build.

I suspect that a Travis build failed because I don't have reference to
a .rubocop.yml file.

I also needed to exclude the `gemfiles/**/*` directory from Rubocop,
because as part of Travis's build, the gems are vendored in gemfiles
directory.
