### PR TITLE
Add Administrative Unit Menu Options

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,6 @@ Documentation:
 Metrics/BlockLength:
   Max: 100
 
-Naming/FileName:
+Style/FileName:
   Exclude:
   - Gemfile

--- a/data/administrative_units.json
+++ b/data/administrative_units.json
@@ -29,7 +29,7 @@
       "predicate_name": "administrative_units",
       "term_label": "University of Notre Dame::Keough School of Global Affairs",
       "classification": "Department",
-      "default_presentation_sequence": 1,
+      "default_presentation_sequence": 2,
       "homepage": "http://keough.nd.edu/",
       "activated_on": "2018-05-02"
     },
@@ -52,7 +52,7 @@
       "term_label": "University of Notre Dame::College of Arts and Letters",
       "grouping": "The Humanities",
       "classification": "College",
-      "default_presentation_sequence": 2,
+      "default_presentation_sequence": 3,
       "homepage": "http://al.nd.edu/",
       "activated_on": "2015-07-22"
     },
@@ -285,7 +285,7 @@
       "predicate_name": "administrative_units",
       "term_label": "University of Notre Dame::Mendoza College of Business",
       "classification": "College",
-      "default_presentation_sequence": 3,
+      "default_presentation_sequence": 4,
       "homepage": "http://mendoza.nd.edu/",
       "activated_on": "2015-07-22"
     },
@@ -328,7 +328,7 @@
       "predicate_name": "administrative_units",
       "term_label": "University of Notre Dame::College of Engineering",
       "classification": "College",
-      "default_presentation_sequence": 4,
+      "default_presentation_sequence": 5,
       "homepage": "http://engineering.nd.edu/",
       "activated_on": "2015-07-22"
     },
@@ -384,7 +384,7 @@
       "predicate_name": "administrative_units",
       "term_label": "University of Notre Dame::College of Science",
       "classification": "College",
-      "default_presentation_sequence": 5,
+      "default_presentation_sequence": 6,
       "homepage": "http://science.nd.edu/",
       "activated_on": "2015-07-22"
     },
@@ -453,7 +453,7 @@
       "predicate_name": "administrative_units",
       "term_label": "University of Notre Dame::First Year of Studies",
       "classification": "College",
-      "default_presentation_sequence": 6,
+      "default_presentation_sequence": 7,
       "homepage": "http://firstyear.nd.edu/",
       "activated_on": "2015-07-22"
     },
@@ -461,7 +461,7 @@
       "predicate_name": "administrative_units",
       "term_label": "University of Notre Dame::Graduate School",
       "classification": "College",
-      "default_presentation_sequence": 7,
+      "default_presentation_sequence": 8,
       "homepage": "http://graduateschool.nd.edu/",
       "activated_on": "2015-07-22"
     },
@@ -469,7 +469,7 @@
       "predicate_name": "administrative_units",
       "term_label": "University of Notre Dame::Law School",
       "classification": "College",
-      "default_presentation_sequence": 8,
+      "default_presentation_sequence": 9,
       "homepage": "http://law.nd.edu/",
       "activated_on": "2015-07-22"
     },
@@ -477,7 +477,7 @@
       "predicate_name": "administrative_units",
       "term_label": "University of Notre Dame::Reserve Officers Training Corps",
       "classification": "College",
-      "default_presentation_sequence": 9,
+      "default_presentation_sequence": 10,
       "activated_on": "2015-07-22"
     },
     {

--- a/lib/locabulary.rb
+++ b/lib/locabulary.rb
@@ -72,6 +72,21 @@ module Locabulary
   end
 
   # @api public
+  #
+  # Responsible for transforming the flat data for the given :predicate_name
+  # an array for use in creating a menu.
+  #
+  # @param [Hash] options
+  # @option options [String] :predicate_name
+  # @option options [Date] :as_of (Date.today)
+  # @return [Array<Hash] - [{ category_title: String, item: Locabulary::Items::Base>}]
+  #
+  # @see Locabulary::Services
+  def self.hierarchical_menu_options(options = {})
+    Services.call(:hierarchical_menu_options, options)
+  end
+
+  # @api public
   # @since 0.5.0
   #
   # For the given :predicate_name and :term_label find an item.

--- a/lib/locabulary/services.rb
+++ b/lib/locabulary/services.rb
@@ -4,6 +4,7 @@ require 'locabulary/services/active_items_for_service'
 require 'locabulary/services/active_hierarchical_roots_service'
 require 'locabulary/services/item_for_service'
 require 'locabulary/services/all_items_for_service'
+require 'locabulary/services/hierarchical_menu_options'
 
 # :nodoc:
 module Locabulary

--- a/lib/locabulary/services/hierarchical_menu_options.rb
+++ b/lib/locabulary/services/hierarchical_menu_options.rb
@@ -1,0 +1,79 @@
+require 'date'
+require 'locabulary/item'
+
+module Locabulary
+  # :nodoc:
+  module Services
+    # @api private
+    # Responsible for transforming the flat data for the given :predicate_name
+    # into a hierarchy.
+    class HierarchicalMenuOptionsService
+      def self.cache
+        @cache ||= {}
+      end
+      private_class_method :cache
+
+      # @api private
+      def self.reset_cache!
+        @cache = {}
+      end
+
+      # @api private
+      # @param options [Array<Locabulary::Items] :roots (ActiveHierarchicalRoots from ActiveHierarchicalRootsService
+      # @return [Array<Hash] - Formatted hashes for admin unit selection menu
+      def self.call(options = {})
+        roots = options.fetch(:roots)
+        cache[roots] ||= new(options).call
+      end
+
+      private_class_method :new
+
+      def initialize(options = {})
+        @roots = options.fetch(:roots)
+      end
+
+      def call
+        make_items_list_for(roots)
+      end
+
+      private
+
+      def make_items_list_for(roots)
+        @items_list = []
+        roots.each do |admin_unit|
+          add_items_to_list_for(item: admin_unit)
+        end
+        @items_list
+      end
+
+      def add_items_to_list_for(item:)
+        item.children.each do |admin_unit|
+          if admin_unit.selectable?
+            add_list_item(parent: item, item: admin_unit)
+          else
+            add_children_to_list_for(item: admin_unit)
+          end
+        end
+      end
+
+      def add_list_item(parent:, item:)
+        # University of Notre Dame is a three-level hierarchy. We only show two levels in the menu
+        parent = item if parent.term_label == "University of Notre Dame"
+        category_title = parent.selectable_label
+        # if this is a new heading, add it to the array
+        if (@items_list.find { |f| f[:category_title] == category_title }).nil?
+          @items_list << { category_title: category_title }
+        end
+        # now add the item to the array
+        @items_list << { category_title: category_title, item: item }
+      end
+
+      def add_children_to_list_for(item:)
+        add_items_to_list_for(item: item)
+      end
+
+      attr_reader :roots
+    end
+    private_constant :HierarchicalMenuOptionsService
+  end
+end

--- a/lib/locabulary/utility.rb
+++ b/lib/locabulary/utility.rb
@@ -46,6 +46,8 @@ module Locabulary
     # @return [Boolean]
     # @see Locabulary::Schema
     def self.data_is_active?(data, as_of)
+      return false unless data_was_ever_active?(data)
+      return true if as_of == :all
       activated_on = Date.parse(data.fetch('activated_on'))
       return false unless activated_on < as_of
       deactivated_on_value = data['deactivated_on']

--- a/spec/lib/locabulary/services/hierarchical_menu_items_spec.rb
+++ b/spec/lib/locabulary/services/hierarchical_menu_items_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'locabulary/services/hierarchical_menu_options'
+
+module Locabulary
+  module Services
+    RSpec.describe HierarchicalMenuOptionsService do
+      let(:roots) { ActiveHierarchicalRootsService.call(predicate_name: 'administrative_units') }
+
+      context '.call' do
+        before { described_class.reset_cache! }
+        after { described_class.reset_cache! }
+        subject { described_class.call(roots: roots) }
+        it 'works on the existing administrative_units and is well-formed' do
+          results = subject
+          expect(results).to be_a(Array)
+          expect(results.size).to be > 1
+          results.each do |result|
+            expect(result).to be_a(Hash)
+            expect(result[:category_title]).to be_a(String)
+            expect(result[:item]).to be_a(Locabulary::Items::AdministrativeUnit) unless result[:item].nil?
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/locabulary/utility_spec.rb
+++ b/spec/lib/locabulary/utility_spec.rb
@@ -5,6 +5,15 @@ module Locabulary
   RSpec.describe Utility do
     context '.data_is_active?' do
       let(:as_of) { Date.parse('2015-10-23') }
+
+      describe 'with as_of: :all' do
+        let(:as_of) { :all }
+
+        it 'returns true' do
+          expect(described_class.send(:data_is_active?, { 'activated_on' => '2015-11-23' }, as_of)).to eq(true)
+        end
+      end
+
       it 'returns false if the data not yet activated' do
         expect(described_class.send(:data_is_active?, { 'activated_on' => '2015-11-23' }, as_of)).to eq(false)
       end

--- a/spec/lib/locabulary_spec.rb
+++ b/spec/lib/locabulary_spec.rb
@@ -13,6 +13,14 @@ module Locabulary
       end
     end
 
+    context '.build_ordered_hierarchical_tree' do
+      it 'will delegate to Services' do
+        parameters = { predicate_name: 'predicate_name', faceted_items: [1, 2, 3], faceted_item_hierarchy_delimiter: ':' }
+        expect(Services).to receive(:call).with(:build_ordered_hierarchical_tree, parameters)
+        described_class.build_ordered_hierarchical_tree(parameters)
+      end
+    end
+
     context '.active_items_for' do
       it 'will delegate to Services' do
         parameters = { predicate_name: 'predicate_name' }
@@ -34,6 +42,14 @@ module Locabulary
         parameters = { predicate_name: 'predicate_name' }
         expect(Services).to receive(:call).with(:active_hierarchical_roots, parameters)
         described_class.active_hierarchical_roots(parameters)
+      end
+    end
+
+    context '.hierarchical_menu_options' do
+      it 'will delegate to Services' do
+        parameters = { roots: [] }
+        expect(Services).to receive(:call).with(:hierarchical_menu_options, parameters)
+        described_class.hierarchical_menu_options(parameters)
       end
     end
 


### PR DESCRIPTION
* Add method to load Administrative Units into an array of items for use in selection menus.
* Support retrieval of items with all dates.
* Change duplicate `default_presentation_sequence` in Administrative Unit data.
* Change `rubocop.yml` to use `Style/FileName:`